### PR TITLE
Make indent guides less prominent

### DIFF
--- a/index.less
+++ b/index.less
@@ -3,6 +3,10 @@
   color: #000000;
 }
 
+.editor .indent-guide {
+  box-shadow: inset 1px 0 #f8f8f9;
+}
+
 .editor.is-focused .cursor {
   border-color: #000000;
 }


### PR DESCRIPTION
Indent guides were very prominent (`#000`). Changed to a light grey (`#f8f8f9`) to match the Sublime theme
